### PR TITLE
PP-12109 invocation resilience

### DIFF
--- a/bin-ranges-transfer/src/main/java/uk/gov/pay/java_lambdas/bin_ranges_transfer/App.java
+++ b/bin-ranges-transfer/src/main/java/uk/gov/pay/java_lambdas/bin_ranges_transfer/App.java
@@ -57,7 +57,10 @@ public class App implements RequestHandler<Void, Candidate> {
     @Override
     public Candidate handleRequest(Void input, final Context context) {
         logger.info("fn: {}, version: {}.", context.getFunctionName(), context.getFunctionVersion());
-        sshClient.start();
+        // sometimes Lambda reuses the execution context so the client is not stopped when we expect it to be
+        if (!sshClient.isStarted()) {
+            sshClient.start();
+        }
         try (ClientSession session = sshClient.connect(getSftpUsername(), getSftpHost(), getSftpPort())
             .verify()
             .getSession()) {


### PR DESCRIPTION
### WHAT

Sometimes, AWS Lambda just pauses the execution context, meaning that `finally` blocks are not guaranteed to be run. 

To prevent invocation failure, we're checking to see if the SSH client has already been started (not closed during the previous invocation due to execution freeze).