### PR TITLE
PP-12687: Add dependency review workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -57,3 +57,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2-
       - name: Run tests
         run: mvn --no-transfer-progress clean verify
+
+  dependency-review:
+    name: Dependency Review scan
+    uses: alphagov/pay-ci/.github/workflows/_run-dependency-review.yml@master

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
       - name: Detect secrets
         uses: alphagov/pay-ci/actions/detect-secrets@master
 
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
       - name: Cache Localstack
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: /tmp/.docker-cache
           key: ${{ runner.os }}-localstack-${{ env.LOCALSTACK_TAG }}
@@ -45,12 +45,12 @@ jobs:
             docker save -o /tmp/.docker-cache/localstack.tar localstack/localstack:${{ env.LOCALSTACK_TAG }}
           fi
       - name: Set up JDK 21
-        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
         with:
           java-version: '21'
           distribution: 'corretto'
       - name: Cache Maven packages
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
We want to run the [dependency-review shared workflow](https://github.com/alphagov/pay-ci/pull/1329) on pull requests in this repository, to replace the Snyk PR checks.

There's only 1 workflow file in this repository, so I decided to keep things simple and append the dependency-review job to it (rather than creating a new `pr.yml` file).

This PR:

- includes the dependency-review action in the run-tests.yml workflow
- updates the deprecated Github Actions versions