### PR TITLE
BAU: Update deprecated actions/cache to v4.2.0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
       - name: Cache Localstack
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4.2.0
         with:
           path: /tmp/.docker-cache
           key: ${{ runner.os }}-localstack-${{ env.LOCALSTACK_TAG }}
@@ -50,7 +50,7 @@ jobs:
           java-version: '21'
           distribution: 'corretto'
       - name: Cache Maven packages
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4.2.0
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
Github deprecated the version of actions/cache we were using. [We need to upgrade to v4.2.0](https://github.com/actions/cache/releases/tag/v4.2.0).